### PR TITLE
Fix NameError in API (add aiofiles.os import)

### DIFF
--- a/api/app/routes/file.py
+++ b/api/app/routes/file.py
@@ -5,6 +5,7 @@ import time
 from json import JSONDecodeError
 
 import aiofiles
+import aiofiles.os
 from fastapi import APIRouter, HTTPException, Header, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 

--- a/api/app/routes/upload.py
+++ b/api/app/routes/upload.py
@@ -4,6 +4,7 @@ import secrets
 from random import choice
 
 import aiofiles
+import aiofiles.os
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 
 from ..db import redis


### PR DESCRIPTION
When uploading a file, the worker was consistently exiting with the following error:

```
[truncated]
  File "/app/app/routes/upload.py", line 93, in handle_upload
    await aiofiles.os.rename(
AttributeError: module 'aiofiles' has no attribute 'os'
[2023-05-28 14:07:27 +0000] [14] [ERROR] closing handshake failed
```

Fixed by importing it separately as advised in this issue: https://github.com/Tinche/aiofiles/issues/130